### PR TITLE
ユーザー情報更新機能実装

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,14 +1,19 @@
+import datetime
+import uvicorn
 from fastapi import FastAPI, status, Depends, HTTPException
-from schemas import UserCreate
-from utils import hash_password
+from schemas import UserCreate, NameUpdate, EmailUpdate, PasswordUpdate
+from utils import hash_password, compare_hash
 import models
 from database import get_db
 from sqlalchemy.orm import Session
 from rabbitmq import publish_message
+from logging import getLogger
 
 app = FastAPI()
+logger = getLogger("uvicorn")
 
 REGISTER_MAIL_QUEUE_NAME = "register_mail_queue"
+UPDATE_MAIL_QUEUE_NAME = "update_mail_queue"
 
 
 @app.post("/", status_code=status.HTTP_201_CREATED)
@@ -17,10 +22,81 @@ def create_user(user: UserCreate, db: Session = Depends(get_db)) -> None:
         models.User.email == user.email).first()
     if user_exists:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
-                            detail=f"{user.email} is already registered")
+                            detail=f"メールアドレス{user.email} はすでに登録されています。")
     user.password = hash_password(user.password)
     new_user = models.User(**user.dict())
     db.add(new_user)
     db.commit()
     db.refresh(new_user)
     publish_message(user.email, REGISTER_MAIL_QUEUE_NAME)
+
+
+@app.patch("/username/{user_id}", status_code=status.HTTP_200_OK)
+def update_username(user_id: int, request: NameUpdate,
+                    db: Session = Depends(get_db)) -> None:
+    db_query = db.query(models.User).filter(
+        models.User.username == request.current_username,
+        models.User.id == user_id)
+    user_exists = db_query.first()
+    if not user_exists:
+        logger.warning(
+            f"Invalid update request came to /username/{user_id}. Request's "
+            f"current_username was {request.current_username}, but didn't "
+            f"matched user:{user_id}'s username.")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail=f"不正なユーザー情報が送信されました。")
+    db_query.update({models.User.username: request.new_username,
+                     models.User.updated_at: datetime.datetime.now()},
+                    synchronize_session=False)
+    db.commit()
+    logger.info(f"User id:{user_id} updated username")
+
+
+@app.patch("/email/{user_id}", status_code=status.HTTP_200_OK)
+def update_email(user_id: int, request: EmailUpdate,
+                 db: Session = Depends(get_db)) -> None:
+    db_query = db.query(models.User).filter(
+        models.User.email == request.current_email, models.User.id == user_id)
+    user_exists = db_query.first()
+    if not user_exists:
+        logger.warning(
+            f"Invalid update request came to /email/{user_id}. Request's "
+            f"current_email was {request.current_email}, but didn't matched "
+            f"user:{user_id}'s email.")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail=f"不正なユーザー情報が送信されました。")
+    email_exists = db.query(models.User).filter(
+        models.User.email == request.new_email).first()
+    if email_exists:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail=f"{request.new_email} はすでに登録されています。")
+
+    db_query.update({models.User.email: request.new_email,
+                     models.User.updated_at: datetime.datetime.now()},
+                    synchronize_session=False)
+    db.commit()
+    publish_message(request.new_email, UPDATE_MAIL_QUEUE_NAME)
+    logger.info(f"User id:{user_id} updated email")
+
+
+@app.patch("/password/{user_id}", status_code=status.HTTP_200_OK)
+def update_password(user_id: int, request: PasswordUpdate,
+                    db: Session = Depends(get_db)) -> None:
+    db_query = db.query(models.User).filter(models.User.id == user_id)
+    user = db_query.first()
+    password_matched = compare_hash(
+        request.current_password,
+        user.password)
+    if not password_matched:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="入力されたパスワードが間違っています。")
+    db_query.update(
+        {models.User.password: hash_password(request.new_password),
+         models.User.updated_at: datetime.datetime.now()},
+        synchronize_session=False)
+    db.commit()
+    logger.info(f"User id:{user_id} updated password")
+
+
+if __name__ == "__main__":
+    uvicorn.run("main:app", host="0.0.0.0", port=5000, reload=True)

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -6,3 +6,18 @@ class UserCreate(BaseModel):
     username: str
     email: EmailStr
     password: str
+
+
+class NameUpdate(BaseModel):
+    current_username: str
+    new_username: str
+
+
+class EmailUpdate(BaseModel):
+    current_email: EmailStr
+    new_email: EmailStr
+
+
+class PasswordUpdate(BaseModel):
+    current_password: str
+    new_password: str

--- a/app/utils.py
+++ b/app/utils.py
@@ -5,3 +5,11 @@ from os import environ
 def hash_password(password: str) -> hex:
     salt = environ.get("SALT")
     return sha256((password + salt).encode()).hexdigest()
+
+
+def compare_hash(raw_password: str, hashed_password: str) -> bool:
+    hashed = hash_password(raw_password)
+    if hashed == hashed_password:
+        return True
+    else:
+        return False


### PR DESCRIPTION
## ユーザー情報更新
ユーザー名、メールアドレス、パスワードそれぞれに更新用のエンドポイントを作成。また、更新前の現在の値と更新したい値をリクエストとして受け取るためschemas.pyに各classを作成。
## ユーザー名とメールアドレスの更新
クエリーパラメータとして渡されたuser_idと、現在の値として渡されたフィールド(`current_username`または`current_email`)の値を用いて`db_query`を作成し`first()`メソッドでDBにクエリーを投げる。DBからユーザー情報が取得できたら続いて値を更新する。 DBからユーザー情報が取得できない場合、不正な入力が来た事になるためエラーメッセージを返す。
## パスワード更新
クエリーパラメータとして渡されたuser_idを用いて`db_query`を作成し`first()`メソッドでDBにクエリーを投げる。
ユーザー情報が取得できた場合、utils.pyの`compare_hash`関数で現在のパスワードとして入力された値とDB内のハッシュ化されたパスワードを比較する。一致した場合、続いてパスワードを更新する。一致しない場合、エラーメッセージを返す。