### PR TITLE
コードの分割

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -1,4 +1,0 @@
-import sys
-from pathlib import Path
-
-sys.path.append(str(Path(__file__).parent))

--- a/app/main.py
+++ b/app/main.py
@@ -1,68 +1,18 @@
 import uvicorn
-from fastapi import FastAPI, status, Depends, HTTPException
+from fastapi import FastAPI
 import threading
 from anyio._backends._asyncio import WorkerThread
 from logging import getLogger
-from sqlalchemy.orm import Session
 
-from schemas import UserCreateReq, LoginData
-from utils import hash_password, compare_hash, check_token
-import app.models as models
-from database import get_db
-from rabbitmq import publish_message, ConsumerThread
-from access_token import create_access_token
-from routers import update, show
+from rabbitmq import ConsumerThread
+from routers import register, update, show, auth
 
 logger = getLogger("uvicorn")
 app = FastAPI()
 app.include_router(show.router)
 app.include_router(update.router)
-
-
-@app.post("/register", status_code=status.HTTP_201_CREATED)
-def create_user(req: UserCreateReq, db: Session = Depends(get_db)) -> None:
-    user_data = req.user_data
-    token_data = req.token_data
-    exception = check_token(token=token_data.token, email=user_data.email,
-                            req_action=token_data.action, db=db)
-    if exception:
-        raise exception
-
-    user_exists = db.query(models.User).filter(
-        models.User.email == user_data.email).first()
-    if user_exists:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
-                            detail=f"メールアドレス{user_data.email} "
-                                   f"はすでに登録されています。")
-    user_data.password = hash_password(user_data.password)
-    new_user = models.User(**user_data.dict())
-    db.add(new_user)
-    db.commit()
-    db.refresh(new_user)
-    publish_message(message={"email": user_data.email},
-                    queue_name="confirm_register_email")
-
-
-@app.post("/login", status_code=status.HTTP_200_OK)
-def login(
-        login_data: LoginData,
-        db: Session = Depends(get_db)) -> HTTPException or dict:
-    user = db.query(
-        models.User.id, models.User.username, models.User.password).filter(
-        models.User.email == login_data.email).first()
-
-    if not user:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
-                            detail="入力されたパスワードが間違っています。")
-
-    password_matched = compare_hash(login_data.password, user.password)
-    if not password_matched:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
-                            detail="入力されたパスワードが間違っています。")
-    access_token = create_access_token({"user_id": user.id})
-    logger.info(f"User id:{user.id} , username:{user.username} logged in.")
-
-    return {"access_token": access_token}
+app.include_router(register.router)
+app.include_router(auth.router)
 
 
 @app.on_event("shutdown")

--- a/app/main.py
+++ b/app/main.py
@@ -9,13 +9,16 @@ from sqlalchemy.orm import Session
 from schemas import (UserCreateReq, UserOut, NameUpdate, EmailUpdate,
                      PasswordUpdate, LoginData)
 from utils import hash_password, compare_hash, check_token
-import models
+import app.models as models
 from database import get_db
 from rabbitmq import publish_message, ConsumerThread
 from access_token import create_access_token, verify_access_token
+from routers import update
 
 app = FastAPI()
 logger = getLogger("uvicorn")
+
+app.include_router(update.router)
 
 
 @app.post("/register", status_code=status.HTTP_201_CREATED)
@@ -61,113 +64,6 @@ def get_user(req: Request, db: Session = Depends(get_db)) -> UserOut:
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"ユーザー情報が取得できませんでした。")
     return user
-
-
-@app.patch("/update/username", status_code=status.HTTP_200_OK)
-def update_username(
-        update_data: NameUpdate,
-        req: Request,
-        db: Session = Depends(get_db)) -> HTTPException or None:
-    access_token = req.cookies.get("access_token")
-    if not access_token:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="ログインしていません。")
-    token_data, error = verify_access_token(access_token)
-    if error:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=error)
-    db_query = db.query(models.User).filter(
-        models.User.username == update_data.current_username,
-        models.User.id == token_data.user_id)
-    user_exists = db_query.first()
-    if not user_exists:
-        logger.warning(
-            f"Invalid update request came to /update/username . Request's "
-            f"current_username was {update_data.current_username}, but didn't "
-            f"matched user:{token_data.user_id}'s username.")
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
-                            detail=f"不正なユーザー情報が送信されました。")
-    db_query.update(
-        {models.User.username: update_data.new_username,
-         models.User.updated_at: datetime.datetime.now()},
-        synchronize_session=False)
-    db.commit()
-    logger.info(f"User id:{token_data.user_id} updated username")
-
-
-@app.patch("/update/email", status_code=status.HTTP_200_OK)
-def update_email(
-        update_data: EmailUpdate,
-        req: Request,
-        db: Session = Depends(get_db)) -> None:
-    access_token = req.cookies.get("access_token")
-    if not access_token:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="ログインしていません。")
-    token_data, error = verify_access_token(access_token)
-    if error:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=error)
-    db_query = db.query(models.User).filter(
-        models.User.email == update_data.current_email,
-        models.User.id == token_data.user_id)
-    user_exists = db_query.first()
-    if not user_exists:
-        logger.warning(
-            f"Invalid update request came to /email/{token_data.user_id}. "
-            f"Request's current_email was {update_data.current_email}, "
-            f"but didn't matched user:{token_data.user_id}'s email.")
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
-                            detail=f"不正なユーザー情報が送信されました。")
-    email_exists = db.query(models.User.email).filter(
-        models.User.email == update_data.new_email).first()
-    if email_exists:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
-                            detail=f"{update_data.new_email} はすでに登録されています。")
-
-    db_query.update({models.User.email: update_data.new_email,
-                     models.User.updated_at: datetime.datetime.now()},
-                    synchronize_session=False)
-    db.commit()
-    publish_message(message={"email": update_data.new_email},
-                    queue_name="update_email_email")
-    logger.info(f"User id:{token_data.user_id} updated email")
-
-
-@app.patch("/update/password", status_code=status.HTTP_200_OK)
-def update_password(
-        update_data: PasswordUpdate,
-        req: Request,
-        db: Session = Depends(get_db)) -> None:
-    access_token = req.cookies.get("access_token")
-    if not access_token:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail="ログインしていません。")
-    token_data, error = verify_access_token(access_token)
-    if error:
-        raise HTTPException(
-            status_code=status.HTTP_401_UNAUTHORIZED,
-            detail=error)
-    db_query = db.query(models.User).filter(
-        models.User.id == token_data.user_id)
-    user = db_query.first()
-    password_matched = compare_hash(
-        raw_password=update_data.current_password,
-        hashed_password=user.password)
-    if not password_matched:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
-                            detail="入力されたパスワードが間違っています。")
-    db_query.update(
-        {models.User.password: hash_password(update_data.new_password),
-         models.User.updated_at: datetime.datetime.now()},
-        synchronize_session=False)
-    db.commit()
-    logger.info(f"User id:{token_data.user_id} updated password")
 
 
 @app.post("/login", status_code=status.HTTP_200_OK)

--- a/app/rabbitmq.py
+++ b/app/rabbitmq.py
@@ -9,7 +9,7 @@ import sys
 import json
 
 from database import SessionLocal
-from models import Token, Action
+from app.models import Token, Action
 
 USER = environ.get("RABBITMQ_USER")
 PASSWORD = environ.get("RABBITMQ_PASSWORD")

--- a/app/routers/auth.py
+++ b/app/routers/auth.py
@@ -1,0 +1,34 @@
+from fastapi import status, Depends, HTTPException, APIRouter
+from sqlalchemy.orm import Session
+from logging import getLogger
+
+from app.schemas import LoginData
+from app.utils import compare_hash
+import app.models as models
+from app.database import get_db
+from app.access_token import create_access_token
+
+router = APIRouter(prefix="/auth")
+logger = getLogger("uvicorn")
+
+
+@router.post("/login", status_code=status.HTTP_200_OK)
+def login(
+        login_data: LoginData,
+        db: Session = Depends(get_db)) -> HTTPException or dict:
+    user = db.query(
+        models.User.id, models.User.username, models.User.password).filter(
+        models.User.email == login_data.email).first()
+
+    if not user:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="入力されたパスワードが間違っています。")
+
+    password_matched = compare_hash(login_data.password, user.password)
+    if not password_matched:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="入力されたパスワードが間違っています。")
+    access_token = create_access_token({"user_id": user.id})
+    logger.info(f"User id:{user.id} , username:{user.username} logged in.")
+
+    return {"access_token": access_token}

--- a/app/routers/check_access_token.py
+++ b/app/routers/check_access_token.py
@@ -1,0 +1,18 @@
+from fastapi import status, HTTPException, Request
+
+from app.access_token import verify_access_token
+
+
+class CheckAccessToken(object):
+    async def __call__(self, request: Request) -> str | None:
+        access_token: str = request.cookies.get("access_token")
+        if not access_token:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="ログインしていません。")
+        token_data, error = verify_access_token(access_token)
+        if error:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=error)
+        return token_data

--- a/app/routers/register.py
+++ b/app/routers/register.py
@@ -1,0 +1,36 @@
+from fastapi import status, Depends, HTTPException, APIRouter
+from sqlalchemy.orm import Session
+from logging import getLogger
+
+from app.schemas import UserCreateReq
+from app.utils import hash_password, check_token
+import app.models as models
+from app.database import get_db
+from app.rabbitmq import publish_message
+
+router = APIRouter()
+logger = getLogger("uvicorn")
+
+
+@router.post("/register", status_code=status.HTTP_201_CREATED)
+def create_user(req: UserCreateReq, db: Session = Depends(get_db)) -> None:
+    user_data = req.user_data
+    token_data = req.token_data
+    exception = check_token(token=token_data.token, email=user_data.email,
+                            req_action=token_data.action, db=db)
+    if exception:
+        raise exception
+
+    user_exists = db.query(models.User).filter(
+        models.User.email == user_data.email).first()
+    if user_exists:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail=f"メールアドレス{user_data.email} "
+                                   f"はすでに登録されています。")
+    user_data.password = hash_password(user_data.password)
+    new_user = models.User(**user_data.dict())
+    db.add(new_user)
+    db.commit()
+    db.refresh(new_user)
+    publish_message(message={"email": user_data.email},
+                    queue_name="confirm_register_email")

--- a/app/routers/show.py
+++ b/app/routers/show.py
@@ -1,0 +1,27 @@
+from fastapi import status, Depends, HTTPException, APIRouter
+from logging import getLogger
+from sqlalchemy.orm import Session
+
+from app.schemas import JWTData, UserOut
+import app.models as models
+from app.database import get_db
+from app.routers.check_access_token import CheckAccessToken
+
+router = APIRouter(prefix="/show")
+logger = getLogger("uvicorn")
+
+oauth2 = CheckAccessToken()
+
+
+@router.get("/user_data", status_code=status.HTTP_200_OK,
+            response_model=UserOut)
+def get_user(token_data: JWTData = Depends(oauth2),
+             db: Session = Depends(get_db)) -> UserOut or HTTPException:
+    print(token_data)
+    user = db.query(models.User.username, models.User.email).filter(
+        models.User.id == token_data.user_id).first()
+    if not user:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"ユーザー情報が取得できませんでした。")
+    return user

--- a/app/routers/update.py
+++ b/app/routers/update.py
@@ -1,0 +1,121 @@
+import datetime
+from fastapi import status, Depends, HTTPException, Request, APIRouter
+from logging import getLogger
+from sqlalchemy.orm import Session
+
+from app.schemas import NameUpdate, EmailUpdate, PasswordUpdate
+from app.utils import hash_password, compare_hash
+import app.models as models
+from app.database import get_db
+from app.rabbitmq import publish_message
+from app.access_token import verify_access_token
+
+router = APIRouter(prefix="/update")
+logger = getLogger("uvicorn")
+
+
+@router.patch("/username", status_code=status.HTTP_200_OK)
+def update_username(
+        update_data: NameUpdate,
+        req: Request,
+        db: Session = Depends(get_db)) -> HTTPException or None:
+    access_token = req.cookies.get("access_token")
+    if not access_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="ログインしていません。")
+    token_data, error = verify_access_token(access_token)
+    if error:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=error)
+    db_query = db.query(models.User).filter(
+        models.User.username == update_data.current_username,
+        models.User.id == token_data.user_id)
+    user_exists = db_query.first()
+    if not user_exists:
+        logger.warning(
+            f"Invalid update request came to /update/username . Request's "
+            f"current_username was {update_data.current_username}, but didn't "
+            f"matched user:{token_data.user_id}'s username.")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail=f"不正なユーザー情報が送信されました。")
+    db_query.update(
+        {models.User.username: update_data.new_username,
+         models.User.updated_at: datetime.datetime.now()},
+        synchronize_session=False)
+    db.commit()
+    logger.info(f"User id:{token_data.user_id} updated username")
+
+
+@router.patch("/email", status_code=status.HTTP_200_OK)
+def update_email(
+        update_data: EmailUpdate,
+        req: Request,
+        db: Session = Depends(get_db)) -> None:
+    access_token = req.cookies.get("access_token")
+    if not access_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="ログインしていません。")
+    token_data, error = verify_access_token(access_token)
+    if error:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=error)
+    db_query = db.query(models.User).filter(
+        models.User.email == update_data.current_email,
+        models.User.id == token_data.user_id)
+    user_exists = db_query.first()
+    if not user_exists:
+        logger.warning(
+            f"Invalid update request came to /email/{token_data.user_id}. "
+            f"Request's current_email was {update_data.current_email}, "
+            f"but didn't matched user:{token_data.user_id}'s email.")
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail=f"不正なユーザー情報が送信されました。")
+    email_exists = db.query(models.User.email).filter(
+        models.User.email == update_data.new_email).first()
+    if email_exists:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail=f"{update_data.new_email} はすでに登録されています。")
+
+    db_query.update({models.User.email: update_data.new_email,
+                     models.User.updated_at: datetime.datetime.now()},
+                    synchronize_session=False)
+    db.commit()
+    publish_message(message={"email": update_data.new_email},
+                    queue_name="update_email_email")
+    logger.info(f"User id:{token_data.user_id} updated email")
+
+
+@router.patch("/password", status_code=status.HTTP_200_OK)
+def update_password(
+        update_data: PasswordUpdate,
+        req: Request,
+        db: Session = Depends(get_db)) -> None:
+    access_token = req.cookies.get("access_token")
+    if not access_token:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="ログインしていません。")
+    token_data, error = verify_access_token(access_token)
+    if error:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail=error)
+    db_query = db.query(models.User).filter(
+        models.User.id == token_data.user_id)
+    user = db_query.first()
+    password_matched = compare_hash(
+        raw_password=update_data.current_password,
+        hashed_password=user.password)
+    if not password_matched:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST,
+                            detail="入力されたパスワードが間違っています。")
+    db_query.update(
+        {models.User.password: hash_password(update_data.new_password),
+         models.User.updated_at: datetime.datetime.now()},
+        synchronize_session=False)
+    db.commit()
+    logger.info(f"User id:{token_data.user_id} updated password")

--- a/app/schemas.py
+++ b/app/schemas.py
@@ -44,7 +44,7 @@ class PasswordUpdate(BaseModel):
 
 
 class JWTData(BaseModel):
-    user_id: str
+    user_id: int
 
 
 class LoginData(BaseModel):

--- a/app/utils.py
+++ b/app/utils.py
@@ -4,7 +4,7 @@ from fastapi import HTTPException, status
 from datetime import datetime, timezone
 from sqlalchemy.orm import Session
 
-from models import Token, Action
+from app.models import Token, Action
 
 
 def hash_password(password: str) -> hex:


### PR DESCRIPTION
## `app/main.py`からコードを分割
`app/main.py`から処理ごとにコードを`routers`ディレクトリに分割。
アクセス制御するパスは`app/routers/check_access_token.py`の`CheckAccessToken class`をFastAPIのDependsで呼び出し、access_tokenをCookieから取得するよう変更。

## import時の注意事項
SQLAlchemyの`Model`を使用するmoduleを読み込む際、moduleのパスの書式を統一しないと`Model`に関するインスタンスが複数作られてしまう。例えば、routers package内で`import app.models`とimportし、app package内で`import models`とimportするとエラーが出る。エラーを回避するには、app package内でも`app.models`と絶対パスでimportする必要がある。